### PR TITLE
Added <Prerequisites> to avoid warning in VS 2017

### DIFF
--- a/src/Mono.Debugger.Sample/source.extension.vsixmanifest
+++ b/src/Mono.Debugger.Sample/source.extension.vsixmanifest
@@ -10,6 +10,9 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,)" />
   </Installation>
   <Dependencies />
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="MonoSampleProject" d:TargetPath="|MonoSampleProject;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />


### PR DESCRIPTION
This node is required so VS 2017 doesn't show up a warning message box at install time
telling the user the extension is not compatible.